### PR TITLE
Fix DuckDB S3 endpoint scheme handling

### DIFF
--- a/dbt/profiles/profiles.yml
+++ b/dbt/profiles/profiles.yml
@@ -9,7 +9,8 @@ data_eng_assignment:
       extensions: [httpfs, parquet, json, iceberg]
       settings:
         # --- MinIO / S3 settings for DuckDB ---
-        s3_endpoint: "{{ env_var('AWS_ENDPOINT_URL') }}"          # ชี้ service name ใน docker network
+        # DuckDB จะเติม prefix http:// เอง ดังนั้นต้องตัด scheme ออกจาก endpoint ที่มาจาก ENV
+        s3_endpoint: "{{ env_var('AWS_ENDPOINT_URL').replace('http://', '').replace('https://', '') }}"
         s3_use_ssl: false                                         # MinIO ใน compose ใช้ http
         s3_url_style: "{{ env_var('AWS_S3_ADDRESSING_STYLE') }}"  # สำคัญ! ให้ใช้ path-style: s3://bucket/key
         s3_region: "{{ env_var('AWS_DEFAULT_REGION') }}"


### PR DESCRIPTION
## Summary
- strip the http/https scheme from the DuckDB S3 endpoint configuration so DuckDB does not double-prefix the URL
- document the reason for the transformation in the profile for clarity

## Testing
- dbt --version

------
https://chatgpt.com/codex/tasks/task_e_68df684420888330bab8fb030f717dea