### PR TITLE
Ensure Parquet export directory exists before dbt run

### DIFF
--- a/dags/test_dbt.py
+++ b/dags/test_dbt.py
@@ -29,6 +29,7 @@ S3_RAW_PREFIX = os.getenv("S3_RAW_PREFIX", "assignment/raw")
 # ---------------- Local (เฉพาะ temp) ----------------
 AIRFLOW_DATA_DIR = os.getenv("AIRFLOW_DATA_DIR", "/opt/airflow/data")
 TMP_DIR = Path(os.getenv("TMP_DIR", f"{AIRFLOW_DATA_DIR}/tmp"))
+PARQUET_DIR = Path(os.getenv("PARQUET_DIR", f"{AIRFLOW_DATA_DIR}/parquet"))
 CSV_NAME = os.getenv("CSV_NAME", "cdc_data.csv")
 CSV_URL_DEFAULT = "https://data.cdc.gov/api/views/hksd-2xuw/rows.csv?accessType=DOWNLOAD"
 CSV_URL = os.getenv("CSV_URL", CSV_URL_DEFAULT)
@@ -187,6 +188,10 @@ with DAG(
 
         bucket = str(dag.params.get("s3_bucket") or S3_BUCKET)
         parquet_prefix = s3_parquet_prefix or str(dag.params.get("s3_parquet_prefix") or "assignment/parquet")
+
+        # dbt post-hooks copy DuckDB tables to local Parquet files; ensure the
+        # destination folder exists so COPY does not fail with "No such file".
+        PARQUET_DIR.mkdir(parents=True, exist_ok=True)
 
         s3_env = {
             "AWS_ACCESS_KEY_ID": S3_ACCESS_KEY_ID,

--- a/dbt/profiles/profiles.yml
+++ b/dbt/profiles/profiles.yml
@@ -9,7 +9,8 @@ data_eng_assignment:
       extensions: [httpfs, parquet, json, iceberg]
       settings:
         # --- MinIO / S3 settings for DuckDB ---
-        s3_endpoint: "{{ env_var('AWS_ENDPOINT_URL') }}"          # ชี้ service name ใน docker network
+        # DuckDB จะเติม prefix http:// เอง ดังนั้นต้องตัด scheme ออกจาก endpoint ที่มาจาก ENV
+        s3_endpoint: "{{ env_var('AWS_ENDPOINT_URL').replace('http://', '').replace('https://', '') }}"
         s3_use_ssl: false                                         # MinIO ใน compose ใช้ http
         s3_url_style: "{{ env_var('AWS_S3_ADDRESSING_STYLE') }}"  # สำคัญ! ให้ใช้ path-style: s3://bucket/key
         s3_region: "{{ env_var('AWS_DEFAULT_REGION') }}"


### PR DESCRIPTION
## Summary
- create a configurable PARQUET_DIR path used by the Airflow DAG
- ensure the Parquet directory exists before invoking dbt so DuckDB COPY hooks succeed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df684420888330bab8fb030f717dea