### PR TITLE
Upload dbt Parquet outputs to S3 instead of local storage

### DIFF
--- a/dags/test_dbt.py
+++ b/dags/test_dbt.py
@@ -187,6 +187,7 @@ with DAG(
 
         bucket = str(dag.params.get("s3_bucket") or S3_BUCKET)
         parquet_prefix = s3_parquet_prefix or str(dag.params.get("s3_parquet_prefix") or "assignment/parquet")
+        parquet_prefix = parquet_prefix.strip("/")
 
         s3_env = {
             "AWS_ACCESS_KEY_ID": S3_ACCESS_KEY_ID,
@@ -231,7 +232,10 @@ with DAG(
             extra_env=s3_env,
         )
 
-        out_uri = f"s3://{bucket}/{parquet_prefix.rstrip('/')}"
+        if parquet_prefix:
+            out_uri = f"s3://{bucket}/{parquet_prefix}"
+        else:
+            out_uri = f"s3://{bucket}"
         logger.info("[transform_data] completed. Output in: %s", out_uri)
         return out_uri
 

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -23,6 +23,18 @@ models:
 
     marts:
       +materialized: table          # ชั้น marts เป็น table (จะถูก COPY เป็น Parquet)
-      # เขียนผลลัพธ์ของแต่ละ model ใน marts ออกเป็น Parquet หลังรันเสร็จ
+      # เขียนผลลัพธ์ของแต่ละ model ใน marts ออกเป็น Parquet บน S3/MinIO หลังรันเสร็จ
       +post-hook:
-        - "copy (select * from {{ this }}) to '/opt/airflow/data/parquet/{{ this.name }}.parquet' (format parquet);"
+        - |
+          {% set bucket = var('s3_bucket', env_var('S3_BUCKET', 'warehouse')) %}
+          {% set prefix = var('s3_prefix', env_var('S3_PARQUET_PREFIX', 'assignment/parquet')) %}
+          {% if prefix.endswith('/') %}
+            {% set key_prefix = prefix[:-1] %}
+          {% else %}
+            {% set key_prefix = prefix %}
+          {% endif %}
+          {% if key_prefix %}
+            copy (select * from {{ this }}) to 's3://{{ bucket }}/{{ key_prefix }}/{{ this.name }}.parquet' (format parquet, overwrite_or_ignore);
+          {% else %}
+            copy (select * from {{ this }}) to 's3://{{ bucket }}/{{ this.name }}.parquet' (format parquet, overwrite_or_ignore);
+          {% endif %}

--- a/dbt/profiles/profiles.yml
+++ b/dbt/profiles/profiles.yml
@@ -9,7 +9,8 @@ data_eng_assignment:
       extensions: [httpfs, parquet, json, iceberg]
       settings:
         # --- MinIO / S3 settings for DuckDB ---
-        s3_endpoint: "{{ env_var('AWS_ENDPOINT_URL') }}"          # ชี้ service name ใน docker network
+        # DuckDB จะเติม prefix http:// เอง ดังนั้นต้องตัด scheme ออกจาก endpoint ที่มาจาก ENV
+        s3_endpoint: "{{ env_var('AWS_ENDPOINT_URL').replace('http://', '').replace('https://', '') }}"
         s3_use_ssl: false                                         # MinIO ใน compose ใช้ http
         s3_url_style: "{{ env_var('AWS_S3_ADDRESSING_STYLE') }}"  # สำคัญ! ให้ใช้ path-style: s3://bucket/key
         s3_region: "{{ env_var('AWS_DEFAULT_REGION') }}"


### PR DESCRIPTION
## Summary
- update both Airflow DAGs to pass S3 credentials to dbt and treat Parquet outputs as S3 paths
- change the dbt marts post-hook so COPY writes Parquet files straight to S3 rather than the local filesystem
- list uploaded Parquet objects from S3 in the publishing task instead of reading a local directory

## Testing
- python -m compileall dags

------
https://chatgpt.com/codex/tasks/task_e_68df684420888330bab8fb030f717dea