### PR TITLE
Fix DuckDB unnest struct alias for stratification view

### DIFF
--- a/dbt/models/intermediate/int_cdi_strata_long.sql
+++ b/dbt/models/intermediate/int_cdi_strata_long.sql
@@ -16,9 +16,9 @@ unpivoted as (
     v.strat_cat_id, v.strat_cat, v.strat_id, v.strat
   from base
   cross join unnest(array[
-    row(strat_cat_id1, strat_cat1, strat_id1, strat1),
-    row(strat_cat_id2, strat_cat2, strat_id2, strat2),
-    row(strat_cat_id3, strat_cat3, strat_id3, strat3)
+    struct_pack(strat_cat_id := strat_cat_id1, strat_cat := strat_cat1, strat_id := strat_id1, strat := strat1),
+    struct_pack(strat_cat_id := strat_cat_id2, strat_cat := strat_cat2, strat_id := strat_id2, strat := strat2),
+    struct_pack(strat_cat_id := strat_cat_id3, strat_cat := strat_cat3, strat_id := strat_id3, strat := strat3)
   ]) as v(strat_cat_id, strat_cat, strat_id, strat)
   where v.strat_cat_id is not null and v.strat_id is not null
 )


### PR DESCRIPTION
## Summary
- replace the row-based array unnest with struct_pack so DuckDB exposes stratification fields
- keep the intermediate view emitting stratification IDs without compilation errors

## Testing
- dbt run --profiles-dir profiles --select int_cdi_strata_long *(fails: missing dependencies because dbt deps cannot reach hub.getdbt.com through the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e602ae79988330bb593a0f8e68f66d